### PR TITLE
don't lose the child message in the logs because of the Bunyan 'msg' collision

### DIFF
--- a/lib/job-runner.js
+++ b/lib/job-runner.js
@@ -264,11 +264,7 @@ WorkflowJobRunner.prototype.runTask = function (task, chain, cb) {
         // Message may contain one of the 'error', 'cmd', or 'info' members,
         // plus 'result' and 'trace' (optional).
         self.child.on('message', function (msg) {
-            if (self.log.debug()) {
-                self.log.debug({
-                    msg: msg
-                }, 'child process message');
-            }
+            self.log.debug({message: message}, 'child process message');
 
             if (msg.info) {
                 var info = {
@@ -374,7 +370,7 @@ WorkflowJobRunner.prototype.runTask = function (task, chain, cb) {
         });
 
     } catch (ex) {
-        self.log.error({err: ex}, 'Error from child process');
+        self.log.error(ex, 'Error from child process');
         self.onChildExit();
         return cb(ex);
     }


### PR DESCRIPTION
Without this the child actually 'msg' gets overwritten.
