### PR TITLE
fix a bug in job-runner.js

### DIFF
--- a/lib/job-runner.js
+++ b/lib/job-runner.js
@@ -116,7 +116,7 @@ var WorkflowJobRunner = module.exports = function (opts) {
                 uuid,
                 prop,
                 val,
-                meta,
+                //meta,
                 function (err) {
                     lastError = err;
                     if (err && err.name === 'BackendInternalError') {


### PR DESCRIPTION
backend.updateJobProperty() does not support five params like that
