### PR TITLE
#145 scope retryTimedOut to retryTask invocation

### DIFF
--- a/lib/task-runner.js
+++ b/lib/task-runner.js
@@ -122,7 +122,6 @@ var WorkflowTaskRunner = module.exports = function (opts) {
 
     // Number of already run retries:
     var retries = 0;
-    var retryTimedOut = false;
     // Placeholder for timeout identifiers:
     var taskTimeoutId = null;
     var taskFallbackTimeoutId = null;
@@ -262,21 +261,21 @@ var WorkflowTaskRunner = module.exports = function (opts) {
     }
 
     function retryTask(cb) {
+        var retryTimedOut = false;
         retries += 1;
 
         // Set the task timeout when given:
         if (timeout) {
+            retryTimedOut = true;
             clearTaskTimeoutId(taskTimeoutId);
             // Task timeout must be in seconds:
             taskTimeoutId = setTimeout(function () {
-                retryTimedOut = true;
                 return onRetryError('task timeout error', cb);
             }, timeout);
         }
 
         return body(job, function (err, res) {
             if (retryTimedOut) {
-                retryTimedOut = false;
                 return null;
             }
 


### PR DESCRIPTION
This PR resolves the issue of tasks not recovering correctly from a timeout upon retry. Retry error state is reset per retry invocation.