### PR TITLE
#145: scope retryTimedOut to retryTask invocation

### DIFF
--- a/lib/task-runner.js
+++ b/lib/task-runner.js
@@ -122,7 +122,6 @@ var WorkflowTaskRunner = module.exports = function (opts) {
 
     // Number of already run retries:
     var retries = 0;
-    var retryTimedOut = false;
     // Placeholder for timeout identifiers:
     var taskTimeoutId = null;
     var taskFallbackTimeoutId = null;
@@ -262,6 +261,7 @@ var WorkflowTaskRunner = module.exports = function (opts) {
     }
 
     function retryTask(cb) {
+        var retryTimedOut = false;
         retries += 1;
 
         // Set the task timeout when given:
@@ -276,7 +276,6 @@ var WorkflowTaskRunner = module.exports = function (opts) {
 
         return body(job, function (err, res) {
             if (retryTimedOut) {
-                retryTimedOut = false;
                 return null;
             }
 


### PR DESCRIPTION
This resolves the issue of task-runner not being able to recover from a previous timeout state.

Closes #145 