### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/docs/index.restdown
+++ b/docs/index.restdown
@@ -449,7 +449,7 @@ relevant sections included:
         "sandbox": {
             "modules": {
                 "http": "http",
-                "uuid": "node-uuid"
+                "uuid": "uuid"
             },
             "foo": "bar",
             "bool": true,
@@ -519,7 +519,7 @@ required.
   VM where we run our tasks. The key for each member will be the identifier for 
   referring to each object inside a task's `body` and `fallback` functions,
   while the value is what the system will use to require the module.
-  For example: `{uuid: 'node-uuid'}`.
+  For example: `{uuid: 'uuid'}`.
 
   Remember that, by default, only [global node timers](http://nodejs.org/docs/latest/api/timers.html)
   will be available for tasks if nothing is given.

--- a/lib/api.js
+++ b/lib/api.js
@@ -1,7 +1,7 @@
 // Copyright 2014 Pedro P. Candel <kusorbox@gmail.com> All rights reserved.
 var restify = require('restify');
 var util = require('util');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var path = require('path');
 var fs = require('fs');
 var os = require('os');

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -2,7 +2,7 @@
 
 var assert = require('assert-plus');
 var util = require('util');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var fs = require('fs');
 var path = require('path');
 var vasync = require('vasync');

--- a/lib/workflow-factory.js
+++ b/lib/workflow-factory.js
@@ -1,5 +1,5 @@
 // Copyright 2014 Pedro P. Candel <kusorbox@gmail.com>. All rights reserved.
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var util = require('util');
 var crypto = require('crypto');
 

--- a/package.json
+++ b/package.json
@@ -1,48 +1,48 @@
 {
-    "name": "wf",
-    "description": "Tasks Workflows orchestration API and runners",
-    "version": "1.0.2",
-    "repository": {
-        "type": "git",
-        "url": "git://github.com/kusor/node-workflow.git"
-    },
-    "author": "Pedro Palazón Candel <kusorbox@gmail.com> (http://www.joyent.com)",
-    "license": "MIT",
-    "contributors": [
-        "Mark Cavage",
-        "Trent Mick",
-        "Josh Wilsdon",
-        "Bryan Cantrill",
-        "Andrés Rodríquez",
-        "Rob Gulewich",
-        "Fred Kuo"
-    ],
-    "bin": {
-        "workflow-api": "./bin/workflow-api",
-        "workflow-runner": "./bin/workflow-runner"
-    },
-    "main": "lib/index.js",
-    "dependencies": {
-        "assert-plus": "1.0.0",
-        "node-uuid": "1.4.7",
-        "bunyan": "1.8.1",
-        "vasync": "1.6.4",
-        "backoff": "1.2.0",
-        "clone": "0.1.6",
-        "restify": "4.0.3",
-        "sigyan": "0.2.0",
-        "trace-event": "1.3.0"
-    },
-    "scripts": {
-        "test": "./node_modules/.bin/tap ./test/*.test.js"
-    },
-    "devDependencies": {
-        "tap": "~0.3"
-    },
-    "optionalDependencies": {
-        "dtrace-provider": "0.6.0"
-    },
-    "engines": {
-        "node": ">=0.10.0"
-    }
+  "name": "wf",
+  "description": "Tasks Workflows orchestration API and runners",
+  "version": "1.0.2",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/kusor/node-workflow.git"
+  },
+  "author": "Pedro Palazón Candel <kusorbox@gmail.com> (http://www.joyent.com)",
+  "license": "MIT",
+  "contributors": [
+    "Mark Cavage",
+    "Trent Mick",
+    "Josh Wilsdon",
+    "Bryan Cantrill",
+    "Andrés Rodríquez",
+    "Rob Gulewich",
+    "Fred Kuo"
+  ],
+  "bin": {
+    "workflow-api": "./bin/workflow-api",
+    "workflow-runner": "./bin/workflow-runner"
+  },
+  "main": "lib/index.js",
+  "dependencies": {
+    "assert-plus": "1.0.0",
+    "backoff": "1.2.0",
+    "bunyan": "1.8.1",
+    "clone": "0.1.6",
+    "restify": "4.0.3",
+    "sigyan": "0.2.0",
+    "trace-event": "1.3.0",
+    "uuid": "^3.0.0",
+    "vasync": "1.6.4"
+  },
+  "scripts": {
+    "test": "./node_modules/.bin/tap ./test/*.test.js"
+  },
+  "devDependencies": {
+    "tap": "~0.3"
+  },
+  "optionalDependencies": {
+    "dtrace-provider": "0.6.0"
+  },
+  "engines": {
+    "node": ">=0.10.0"
+  }
 }

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -1,6 +1,6 @@
 // Copyright 2012 Pedro P. Candel <kusorbox@gmail.com>. All rights reserved.
 var test = require('tap').test,
-    uuid = require('node-uuid'),
+    uuid = require('uuid'),
     SOCKET = '/tmp/.' + uuid(),
     util = require('util'),
     path = require('path'),

--- a/test/child.test.js
+++ b/test/child.test.js
@@ -1,7 +1,7 @@
 // Copyright 2012 Pedro P. Candel <kusorbox@gmail.com>. All rights reserved.
 var util = require('util'),
     test = require('tap').test,
-    uuid = require('node-uuid'),
+    uuid = require('uuid'),
     fork = require('child_process').fork;
 
 var job = {

--- a/test/config.json.sample
+++ b/test/config.json.sample
@@ -16,7 +16,7 @@
         "sandbox": {
             "modules": {
                 "http": "http",
-                "uuid": "node-uuid"
+                "uuid": "uuid"
             },
             "foo": "bar",
             "bool": true,

--- a/test/config.nofork.sample
+++ b/test/config.nofork.sample
@@ -17,7 +17,7 @@
         "sandbox": {
             "modules": {
                 "http": "http",
-                "uuid": "node-uuid"
+                "uuid": "uuid"
             },
             "foo": "bar",
             "bool": true,

--- a/test/in-memory-backend.test.js
+++ b/test/in-memory-backend.test.js
@@ -1,6 +1,6 @@
 // Copyright 2012 Pedro P. Candel <kusorbox@gmail.com>. All rights reserved.
 var test = require('tap').test,
-    uuid = require('node-uuid'),
+    uuid = require('uuid'),
     SOCKET = '/tmp/.' + uuid(),
     util = require('util'),
     Factory = require('../lib/index').Factory,

--- a/test/job-runner.test.js
+++ b/test/job-runner.test.js
@@ -1,7 +1,7 @@
 // Copyright 2014 Pedro P. Candel <kusorbox@gmail.com>. All rights reserved.
 var util = require('util'),
     test = require('tap').test,
-    uuid = require('node-uuid'),
+    uuid = require('uuid'),
     WorkflowJobRunner = require('../lib/job-runner'),
     bunyan = require('bunyan'),
     Factory = require('../lib/index').Factory,
@@ -604,7 +604,7 @@ test('a job can access explicitly defined sandbox modules', function (t) {
                 job: job,
                 sandbox: {
                     modules: {
-                        uuid: 'node-uuid'
+                        uuid: 'uuid'
                     }
                 },
                 dtrace: DTRACE,

--- a/test/runner.test.js
+++ b/test/runner.test.js
@@ -3,7 +3,7 @@ var util = require('util');
 var path = require('path');
 var fs = require('fs');
 var test = require('tap').test;
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var WorkflowRunner = require('../lib/runner');
 var Factory = require('../lib/index').Factory;
 var exists = fs.exists || path.exists;
@@ -56,12 +56,12 @@ var taskWithModules = {
     retry: 1,
     body: function (job, cb) {
         if (typeof (uuid) !== 'function') {
-            return cb('node-uuid module is not defined');
+            return cb('uuid module is not defined');
         }
         return cb(null);
     },
     modules: {
-        uuid: 'node-uuid'
+        uuid: 'uuid'
     }
 };
 var okWf, failWf, theJob, failWfWithError, failWfWithRetry;

--- a/test/task-runner.test.js
+++ b/test/task-runner.test.js
@@ -1,7 +1,7 @@
 // Copyright 2014 Pedro P. Candel <kusorbox@gmail.com>. All rights reserved.
 var util = require('util'),
     test = require('tap').test,
-    uuid = require('node-uuid'),
+    uuid = require('uuid'),
     WorkflowTaskRunner = require('../lib/task-runner');
 
 var job = {
@@ -31,7 +31,7 @@ var task = {
 var sandbox = {
     'modules': {
         'http': 'http',
-        'uuid': 'node-uuid',
+        'uuid': 'uuid',
         'restify': 'restify'
     },
     'foo': 'bar',
@@ -126,7 +126,7 @@ test('sandbox modules and variables', function (t) {
     var foo, bool, aNumber, restify, info, someError;
     var task_body = function (job, cb) {
         if (typeof (uuid) !== 'function') {
-            return cb('node-uuid module is not defined');
+            return cb('uuid module is not defined');
         }
         if (typeof (foo) !== 'string') {
             return cb('sandbox value is not defined');
@@ -669,7 +669,7 @@ test('a task which defines its own modules', function (t) {
     var foo, bool, aNumber, restify, http;
     var task_body = function (job, cb) {
         if (typeof (uuid) !== 'function') {
-            return cb('node-uuid module is not defined');
+            return cb('uuid module is not defined');
         }
         if (typeof (foo) !== 'string') {
             return cb('sandbox value is not defined');
@@ -691,7 +691,7 @@ test('a task which defines its own modules', function (t) {
 
     task.body = task_body.toString();
     task.modules = {
-        'uuid': 'node-uuid'
+        'uuid': 'uuid'
     };
 
     job.chain.push(task);


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.